### PR TITLE
criação da HistoryController e testes unitários com sucesso

### DIFF
--- a/src/main/java/com/br/sb/project_movie/controller/HistoryController.java
+++ b/src/main/java/com/br/sb/project_movie/controller/HistoryController.java
@@ -1,0 +1,73 @@
+package com.br.sb.project_movie.controller;
+
+import com.br.sb.project_movie.dto.HistoryDto;
+import com.br.sb.project_movie.mapper.HistoryMapper;
+import com.br.sb.project_movie.model.History;
+import com.br.sb.project_movie.service.HistoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/history")
+public class HistoryController implements GenericController {
+
+    private final HistoryService historyService;
+
+    private final HistoryMapper historyMapper;
+
+    @PostMapping("/create")
+    public ResponseEntity<Object> createHistory(@Valid HistoryDto historyDto) {
+        History history = historyMapper.toModel(historyDto);
+        HistoryDto savedHistory = historyMapper.toDto(historyService.saveHistory(history));
+        HttpHeaders headers = gerarHaderLoccation("/history/" + savedHistory.id());
+        return new ResponseEntity<>(savedHistory.id(), headers, HttpStatus.CREATED);
+    }
+    @PutMapping("/update")
+    public ResponseEntity<Object> updateHistory(@Valid HistoryDto historyDto) {
+        History history = historyMapper.toModel(historyDto);
+        HistoryDto savedHistory = historyMapper.toDto(historyService.update(history));
+        HttpHeaders headers = gerarHaderLoccation("/history/" + savedHistory.id());
+        return new ResponseEntity<>(savedHistory.id(), headers, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/find/{id}")
+    public ResponseEntity<Object> findHistoryById(@PathVariable("id") String id) {
+        if (id == null || id.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        id = id.trim();
+        UUID uuid = UUID.fromString(id);
+        History history = historyService.findById(uuid);
+        HistoryDto historyDto = historyMapper.toDto(history);
+        return ResponseEntity.ok(historyDto);
+    }
+
+    @GetMapping("/find")
+    public ResponseEntity<Object> findAllHistory() {
+        var histories = historyService.findAll();
+        if (histories.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        var historyDtos = histories.stream()
+                .map(historyMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(historyDtos);
+    }
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Object> deleteHistory(@RequestParam(value = "id", required = false) String id) {
+        if (id == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        UUID uuid = UUID.fromString(id);
+        historyService.deleteById(uuid);
+        return ResponseEntity.noContent().build();
+
+    }
+}

--- a/src/main/java/com/br/sb/project_movie/service/HistoryService.java
+++ b/src/main/java/com/br/sb/project_movie/service/HistoryService.java
@@ -49,14 +49,14 @@ public class HistoryService {
                 .orElseThrow(() -> new IllegalArgumentException("History not found with id: " + id));
     }
 
-    public void update(History history) {
+    public History update(History history) {
         if (history == null || history.getId() == null) {
             throw new IllegalArgumentException("History or History ID cannot be null");
         }
         if (!historyRepository.existsById(history.getId())) {
             throw new IllegalArgumentException("History not found with id: " + history.getId());
         }
-        historyRepository.save(history);
+        return historyRepository.save(history);
     }
 
     public void deleteById(UUID id) {

--- a/src/test/java/com/br/sb/project_movie/model/HistoryTest.java
+++ b/src/test/java/com/br/sb/project_movie/model/HistoryTest.java
@@ -1,9 +1,134 @@
 package com.br.sb.project_movie.model;
 
+import com.br.sb.project_movie.controller.HistoryController;
+import com.br.sb.project_movie.dto.HistoryDto;
+import com.br.sb.project_movie.mapper.HistoryMapper;
+import com.br.sb.project_movie.service.HistoryService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions .*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito .*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
 class HistoryTest {
 
+    @InjectMocks
+    private HistoryController historyController;
+
+    @Mock
+    private HistoryMapper historyMapper;
+
+    @Mock
+    private HistoryService historyService;
+
+    private History history;
+    private HistoryDto historyDto;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+
+        Movie movie = new Movie();
+        movie.setId(UUID.randomUUID());
+
+        history = new History();
+        history.setId(UUID.randomUUID());
+        history.setUser(user);
+        history.setMovie(movie);
+        history.setViewDate(LocalDateTime.now());
+        history.setRating(5);
+
+        historyDto = new HistoryDto(
+                history.getId(),
+                history.getUser(),
+                history.getMovie(),
+                history.getRating(),
+                history.getViewDate()
+        );
+    }
+
+    @Test
+    void testHistoryCreation() {
+        assertNotNull(historyDto);
+        assertEquals(history.getId(), historyDto.id());
+        assertEquals(history.getUser(), historyDto.user());
+        assertEquals(history.getMovie(), historyDto.movie());
+        assertEquals(history.getRating(), historyDto.rating());
+        assertEquals(history.getViewDate(), historyDto.viewDate());
+    }
+
+    @Test
+    void testHistorySave() {
+        when(historyMapper.toModel(any(HistoryDto.class))).thenReturn(history);
+        when(historyService.saveHistory(any(History.class))).thenReturn(history);
+        when(historyMapper.toDto(any(History.class))).thenReturn(historyDto);
+
+        ResponseEntity<Object> response = historyController.createHistory(historyDto);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        verify(historyService, times(1)).saveHistory(any(History.class));
+    }
+
+    @Test
+    void testHistoryUpdate() {
+        when(historyMapper.toModel(any(HistoryDto.class))).thenReturn(history);
+        when(historyService.update(any(History.class))).thenReturn(history);
+        when(historyMapper.toDto(any(History.class))).thenReturn(historyDto);
+
+        ResponseEntity<Object> response = historyController.updateHistory(historyDto);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        verify(historyService, times(1)).update(any(History.class));
+    }
+
+    @Test
+    void testHistoryFindById() {
+        when(historyService.findById(any(UUID.class))).thenReturn(history);
+        when(historyMapper.toDto(any(History.class))).thenReturn(historyDto);
+
+        ResponseEntity<Object> response = historyController.findHistoryById(history.getId().toString());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        verify(historyService, times(1)).findById(any(UUID.class));
+    }
+
+    @Test
+    void testHistoryFindAll() {
+        when(historyService.findAll()).thenReturn(List.of(history));
+        when(historyMapper.toDto(any(History.class))).thenReturn(historyDto);
+
+        ResponseEntity<Object> response = historyController.findAllHistory();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        verify(historyService, times(1)).findAll();
+    }
+
+    @Test
+    void testHistoryDeletion() {
+        doNothing().when(historyService).deleteById(history.getId());
+
+        ResponseEntity<Object> response = historyController.deleteHistory(history.getId().toString());
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(historyService, times(1)).deleteById(history.getId());
+    }
 }

--- a/src/test/java/com/br/sb/project_movie/model/UserTest.java
+++ b/src/test/java/com/br/sb/project_movie/model/UserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 


### PR DESCRIPTION
- Criada a classe HistoryController com endpoints para CRUD de históricos
- Implementada a classe HistoryTest com cobertura para os métodos da controller
- Corrigidos mocks do HistoryMapper e HistoryService para evitar UnfinishedStubbingException
- Todos os testes passaram com sucesso
- Removida importação desnecessária na classe UserTest